### PR TITLE
Make OHMKit compatible with C++/Objective C++

### DIFF
--- a/Core/ObjectMapping.h
+++ b/Core/ObjectMapping.h
@@ -74,11 +74,17 @@
 
 typedef id(^OHMValueAdapterBlock)(id);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern void OHMMappable(Class c);
 extern void OHMSetMapping(Class c, NSDictionary *mappingDictionary);
 extern void OHMSetAdapter(Class c, NSDictionary *adapterDictionary);
 extern void OHMSetArrayClasses(Class c, NSDictionary *classDictionary);
 extern void OHMSetDictionaryClasses(Class c, NSDictionary *classDictionary);
+#ifdef __cplusplus
+}
+#endif
 
 #pragma mark - Helpers
 


### PR DESCRIPTION
Turn off C++ name mangling. Fixes build errors when including ObjectMapping.h in a C++ or Objective C++ module.
