### PR TITLE
Added reverse adapters and collection support for dehydration

### DIFF
--- a/Core/OHMAdapters.h
+++ b/Core/OHMAdapters.h
@@ -27,6 +27,16 @@ typedef __nullable id(^OHMValueAdapterBlock)(__nullable id);
 extern void OHMSetAdapter(__nonnull Class c, NSDictionary * __nullable adapterDictionary);
 
 /**
+ Sets the dictionary of reverse value adapters for keys.
+ 
+ The key is a KVC key for which you would like to adapt outgoing values. @p NSNumbers do not need adapters to be mapped to primitive properties (e.g. int, NSInteger, float, BOOL). To adapt values to a property with a struct type, create an adapter block that creates the struct, and wrap it in an NSValue object and have the block return that NSValue.
+ 
+ @param c The class on which to set the adapter dictionary.
+ @param dictionary A dictionary target key, value adapter pairs. The target key (or keys in the dictionary) must be a KVC key the class can already respond to. The value must be a block of type @p OHMValueAdapterBlock, or conforming to the signature @p id(^)(id).
+ */
+extern void OHMSetReverseAdapter(__nonnull Class c, NSDictionary * __nullable adapterDictionary);
+
+/**
  Adds the key value pairs from the passed dictionary to the existing adapter dictionary.
 
  The key is a KVC key for which you would like to adapt incoming values. @p NSNumbers do not need adapters to be mapped to primitive properties (e.g. int, NSInteger, float, BOOL). To adapt values to a property with a struct type, create an adapter block that creates the struct, and wrap it in an NSValue object and have the block return that NSValue.
@@ -37,11 +47,29 @@ extern void OHMSetAdapter(__nonnull Class c, NSDictionary * __nullable adapterDi
 extern void OHMAddAdapter(__nonnull Class c, NSDictionary * __nullable adapterDictionary);
 
 /**
+ Adds the key value pairs from the passed dictionary to the existing reverse adapter dictionary.
+ 
+ The key is a KVC key for which you would like to adapt outgoing values. @p NSNumbers do not need adapters to be mapped to primitive properties (e.g. int, NSInteger, float, BOOL). To adapt values to a property with a struct type, create an adapter block that creates the struct, and wrap it in an NSValue object and have the block return that NSValue.
+ 
+ @param c The class on which to set the adapter dictionary.
+ @param dictionary A dictionary target key, value adapter pairs. The target key (or keys in the dictionary) must be a KVC key the class can already respond to. The value must be a block of type @p OHMValueAdapterBlock, or conforming to the signature @p id(^)(id).
+ */
+extern void OHMAddReverseAdapter(__nonnull Class c, NSDictionary * __nullable adapterDictionary);
+
+/**
  Remove the value adapters for each key in @p keyArray on the given class.
 
  @param class The class whose adapters should be removed.
  @param keyArray An array of keys to for which adapters should be removed.
  */
 extern void OHMRemoveAdapter(__nonnull Class c, NSArray * __nullable keyArray);
+
+/**
+ Remove the reverse value adapters for each key in @p keyArray on the given class.
+ 
+ @param class The class whose adapters should be removed.
+ @param keyArray An array of keys to for which adapters should be removed.
+ */
+extern void OHMRemoveReverseAdapter(__nonnull Class c, NSArray * __nullable keyArray);
 
 #endif

--- a/Core/ObjectMapping.h
+++ b/Core/ObjectMapping.h
@@ -55,6 +55,15 @@
 + (void)ohm_setAdapter:(nullable NSDictionary *)dictionary;
 
 /**
+ Sets the dictionary of value reverse adapters for keys.
+ 
+ The key is a KVC key for which you would like to adapt outgoing values. NSNumbers do not need adapters to be mapped to primitive properties (e.g. int, NSInteger, float, BOOL). To adapt values to a property with a struct type, create an adapter block that creates the struct, and wrap it in an NSValue object and have the block return that NSValue.
+ 
+ @param dictionary A dictionary target key, value adapter pairs. The target key (or keys in the dictionary) must be a KVC key the class can already respond to. The value must be a block of type OHMValueAdapterBlock, or conforming to the signature id(^)(id).
+ */
++ (void)ohm_setReverseAdapter:(nullable NSDictionary *)dictionary;
+
+/**
  Sets the dictionary of key to array class.
  
  The key is a KVC key corresponding to an NSAray or NSMutableArray for which you would like to fill with an array of objects of an OHMMappable class when given an array of dictionaries appropriate for hydrating that class.

--- a/Core/ObjectMapping.m
+++ b/Core/ObjectMapping.m
@@ -90,6 +90,32 @@ static NSDictionary * f_ohm_mapping(Class c);
             dictionary[key] = [object dictionaryWithValuesForKeys: OHMMappableKeys([object class])];
         }
         
+        // Array
+        if ([object isKindOfClass: [NSArray class]]) {
+            object = [object mutableCopy];
+            for (int index = 0 ; index < [object count] ; index++) {
+                id value = [object objectAtIndex: index];
+                if ([value conformsToProtocol:@protocol(OHMMappable)]) {
+                    [object replaceObjectAtIndex: index
+                                      withObject: [value dictionaryWithValuesForKeys: OHMMappableKeys([value class])]];
+                }
+            }
+            dictionary[key] = object;
+        }
+
+        // Dictionary
+        if ([object isKindOfClass: [NSDictionary class]]) {
+            object = [object mutableCopy];
+            for (NSString *objectKey in [object allKeys]) {
+                id value = [object objectForKey: objectKey];
+                if ([value conformsToProtocol:@protocol(OHMMappable)]) {
+                    [object setValue: [value dictionaryWithValuesForKeys: OHMMappableKeys([value class])]
+                              forKey: objectKey];
+                }
+            }
+            dictionary[key] = object;
+        }
+
         // Adapter
         NSDictionary *adapters = objc_getAssociatedObject([self class], &_kOMClassReverseAdapterDictionaryKey);
         OHMValueAdapterBlock adapterForKey = adapters[key];

--- a/ObjectMapping/ObjectMappingTests/OMTCollectionClass.m
+++ b/ObjectMapping/ObjectMappingTests/OMTCollectionClass.m
@@ -102,6 +102,11 @@
     
     XCTAssertEqualObjects(arrayModel.arrayOfStrings[0], @"hi", @"Arrays of non-mapped objects should be correctly set");
     XCTAssertEqualObjects(arrayModel.arrayOfStrings[1], @"there", @"Arrays of non-mapped objects should be correctly set");
+
+    NSDictionary *dictionary = [arrayModel dictionaryWithValuesForKeys:OHMMappableKeys([arrayModel class])];
+    
+    XCTAssertEqualObjects(dictionary[@"arrayOfStrings"][0], @"hi", @"Arrays of non-mapped objects should be correctly set");
+    XCTAssertEqualObjects(dictionary[@"arrayOfStrings"][1], @"there", @"Arrays of non-mapped objects should be correctly set");
 }
 
 - (void)testSetDictionaryClass
@@ -133,6 +138,17 @@
     XCTAssertEqualObjects(basicModel2.name, @"Music", @"OTMBasicModel should have its name set with a correct key w/o a mapping dictionary");
     XCTAssertEqualObjects(basicModel2.favoriteWord, @"glitter", @"OTMBasicModel should have its word set with a correct key w/o a mapping dictionary");
     XCTAssertTrue(basicModel2.favoriteNumber==7, @"OTMBasicModel should have its number set with a correct key w/o a mapping dictionary");
+    
+    NSDictionary *dictionary = [dictionaryModel dictionaryWithValuesForKeys:OHMMappableKeys([dictionaryModel class])];
+    
+    XCTAssertEqualObjects(dictionary[@"dictionaryOfBasicModels"][@"key1"][@"name"], @"Fabian", @"Dictionary should have its name set with a correct key w/o a mapping dictionary");
+    XCTAssertEqualObjects(dictionary[@"dictionaryOfBasicModels"][@"key1"][@"favoriteWord"], @"absurd", @"Dictionary should have its word set with a correct key w/o a mapping dictionary");
+    XCTAssertEqualObjects(dictionary[@"dictionaryOfBasicModels"][@"key1"][@"favoriteNumber"], @47, @"Dictionary should have its number set with a correct key w/o a mapping dictionary");
+    
+    XCTAssertEqualObjects(dictionary[@"dictionaryOfBasicModels"][@"key2"][@"name"], @"Music", @"Dictionary should have its name set with a correct key w/o a mapping dictionary");
+    XCTAssertEqualObjects(dictionary[@"dictionaryOfBasicModels"][@"key2"][@"favoriteWord"], @"glitter", @"Dictionary should have its word set with a correct key w/o a mapping dictionary");
+    XCTAssertEqualObjects(dictionary[@"dictionaryOfBasicModels"][@"key2"][@"favoriteNumber"], @7, @"Dictionary should have its number set with a correct key w/o a mapping dictionary");
 }
+
 
 @end

--- a/ObjectMapping/ObjectMappingTests/ObjectMappingTests.m
+++ b/ObjectMapping/ObjectMappingTests/ObjectMappingTests.m
@@ -46,6 +46,7 @@
 - (void)tearDown
 {
     [super tearDown];
+    OHMRemoveReverseAdapter([OMTBasicModel class], @[@"favoriteNumber"]);
 }
 
 #pragma mark - Helper Tests
@@ -219,6 +220,23 @@
     [basicModel setValuesForKeysWithDictionary:@{@"favoriteNumber" : @"fourty-seven"}];
     
     XCTAssertTrue(basicModel.favoriteNumber==47, @"OTMBasicModel should have its number set with a correct key w/o a mapping dictionary");
+}
+
+- (void)testBasicReverseValueAdapter
+{
+    OHMValueAdapterBlock fourtySevenReverseAdapter = ^(id object){
+        if ([object isEqual:@47]) {
+            return @"fourty-seven";
+        }
+        return (NSString*)nil;
+    };
+    OHMSetReverseAdapter([OMTBasicModel class], @{@"favoriteNumber" : fourtySevenReverseAdapter});
+    
+    OMTBasicModel *basicModel = [[OMTBasicModel alloc] init];
+    basicModel.favoriteNumber = 47;
+    
+    NSDictionary *dictionary = [basicModel dictionaryWithValuesForKeys:OHMMappableKeys([OMTBasicModel class])];
+    XCTAssertEqualObjects(dictionary[@"favoriteNumber"], @"fourty-seven", @"Dictionary should have its number set with a correct key w/o a mapping dictionary");
 }
 
 - (void)testValueAdapterMethod

--- a/README.md
+++ b/README.md
@@ -197,6 +197,19 @@ OHMValueAdapterBlock colorFromNumberArray = ^(NSArray *numberArray) {
 OHMSetAdapter([MYModel class], @{@"favoriteColor": colorFromNumberArray, @"leastFavoriteColor": colorFromNumberArray});
 ```
 
+When dehydrating, you can adapt the output with a reverse adapter block:
+
+```objc
+OHMMappable([MYModel class]);
+OHMSetMapping([MYModel class], @"least_favorite_color" : @"leastFavoriteColor", @"favorite_color" : @"favoriteColor")
+OHMValueAdapterBlock numberArrayFromColor = ^(NSColor *color) {
+	CGFloat red, green, blue, alpha;
+	[color getRed: &red green: &green blue: &blue alpha: &alpha];
+	return @[@(red), @(green), @(blue)];
+};
+OHMSetReverseAdapter([MYModel class], @{@"favoriteColor": numberArrayFromColor, @"leastFavoriteColor": colorFromNumberArray});
+```
+
 Note that the key for the adapter is the key on the model object, not on the response. And adapters are added for a property, not a type. If the above example had multiple properties that were colors, you would have to set an adapter block for each property. It would be smart to reuse adapter blocks in your code.
 
 The `OHMValueAdapterBlock` type is a block that takes an `id` and returns an `id`. *i.e* `typedef id(^OHMValueAdapterBlock)(id);`


### PR DESCRIPTION
I realized that it makes sense to have reverse adapters to match the adapter support when dehydrating to a dictionary.

I also realized that collection support needed to be added to dehydration.

Apologies for not including this in the first pull request.