### PR TITLE
Discard properties which aren't relevant to serialization.

### DIFF
--- a/Core/OHMAdapters.h
+++ b/Core/OHMAdapters.h
@@ -9,6 +9,10 @@
 #ifndef OHMKit_OHMAdapters_h
 #define OHMKit_OHMAdapters_h
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  A convenience block type that takes a single @p id and returns a single @p id.
 
@@ -24,7 +28,7 @@ typedef __nullable id(^OHMValueAdapterBlock)(__nullable id);
  @param c The class on which to set the adapter dictionary.
  @param dictionary A dictionary target key, value adapter pairs. The target key (or keys in the dictionary) must be a KVC key the class can already respond to. The value must be a block of type @p OHMValueAdapterBlock, or conforming to the signature @p id(^)(id).
  */
-extern void OHMSetAdapter(__nonnull Class c, NSDictionary * __nullable adapterDictionary);
+extern void OHMSetAdapter(__nonnull Class c, NSDictionary<NSString*, OHMValueAdapterBlock> * __nullable adapterDictionary);
 
 /**
  Sets the dictionary of reverse value adapters for keys.
@@ -34,7 +38,7 @@ extern void OHMSetAdapter(__nonnull Class c, NSDictionary * __nullable adapterDi
  @param c The class on which to set the adapter dictionary.
  @param dictionary A dictionary target key, value adapter pairs. The target key (or keys in the dictionary) must be a KVC key the class can already respond to. The value must be a block of type @p OHMValueAdapterBlock, or conforming to the signature @p id(^)(id).
  */
-extern void OHMSetReverseAdapter(__nonnull Class c, NSDictionary * __nullable adapterDictionary);
+extern void OHMSetReverseAdapter(__nonnull Class c, NSDictionary<NSString*, OHMValueAdapterBlock> * __nullable adapterDictionary);
 
 /**
  Adds the key value pairs from the passed dictionary to the existing adapter dictionary.
@@ -71,5 +75,9 @@ extern void OHMRemoveAdapter(__nonnull Class c, NSArray * __nullable keyArray);
  @param keyArray An array of keys to for which adapters should be removed.
  */
 extern void OHMRemoveReverseAdapter(__nonnull Class c, NSArray * __nullable keyArray);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/Core/OHMArrayMapping.h
+++ b/Core/OHMArrayMapping.h
@@ -17,7 +17,7 @@
  @param class The class on which to set the mapping dictionary.
  @param mappingDictionary A dictionary source key of strings, and target values of OHMMappable classes.
  */
-extern void OHMSetArrayClasses(__nonnull Class class, NSDictionary * __nullable classDictionary);
+extern void OHMSetArrayClasses(__nonnull Class _class, NSDictionary * __nullable classDictionary);
 
 /**
  Adds the key value pairs from the passed dictionary to the existing array mapping dictionary.
@@ -29,7 +29,7 @@ extern void OHMSetArrayClasses(__nonnull Class class, NSDictionary * __nullable 
  @param class The class on which to set the mapping dictionary.
  @param mappingDictionary A dictionary source key of strings, and target values of OHMMappable classes.
  */
-extern void OHMAddArrayClasses(__nonnull Class class, NSDictionary * __nullable classDictionary);
+extern void OHMAddArrayClasses(__nonnull Class _class, NSDictionary * __nullable classDictionary);
 
 /**
  Remove the array mapping class for each key in @p keyArray on the given class.
@@ -37,6 +37,6 @@ extern void OHMAddArrayClasses(__nonnull Class class, NSDictionary * __nullable 
  @param class The class whose array mappings should be removed.
  @param keyArray An array of keys to be removed from array mapping.
  */
-extern void OHMRemoveArray(__nonnull Class class, NSArray * __nullable keyArray);
+extern void OHMRemoveArray(__nonnull Class _class, NSArray * __nullable keyArray);
 
 #endif

--- a/Core/OHMDictionaryMapping.h
+++ b/Core/OHMDictionaryMapping.h
@@ -17,7 +17,7 @@
  @param class The class on which to set the mapping dictionary.
  @param mappingDictionary A dictionary source key of strings, and target values of OHMMappable classes.
  */
-extern void OHMSetDictionaryClasses(__nonnull Class class, NSDictionary * __nullable classDictionary);
+extern void OHMSetDictionaryClasses(__nonnull Class _class, NSDictionary * __nullable classDictionary);
 
 /**
  Adds the key value pairs from the passed dictionary to the existing dictionary mapping dictionary.
@@ -29,7 +29,7 @@ extern void OHMSetDictionaryClasses(__nonnull Class class, NSDictionary * __null
  @param class The class on which to set the mapping dictionary.
  @param mappingDictionary A dictionary source key of strings, and target values of OHMMappable classes.
  */
-extern void OHMAddDictionaryClasses(__nonnull Class class, NSDictionary * __nullable classDictionary);
+extern void OHMAddDictionaryClasses(__nonnull Class _class, NSDictionary * __nullable classDictionary);
 
 /**
  Remove the dictionary mapping class for each key in @p keyArray on the given class.
@@ -37,6 +37,6 @@ extern void OHMAddDictionaryClasses(__nonnull Class class, NSDictionary * __null
  @param class The class whose mappings should be removed.
  @param keyArray An array of keys to be removed from dictionary mapping.
  */
-extern void OHMRemoveDictionary(__nonnull Class class, NSArray * __nullable keyArray);
+extern void OHMRemoveDictionary(__nonnull Class _class, NSArray * __nullable keyArray);
 
 #endif

--- a/Core/ObjectMapping.h
+++ b/Core/ObjectMapping.h
@@ -96,7 +96,7 @@ extern void OHMMappable(__nonnull Class c);
  
  @param c The class for which to get the mapped keys array.
  */
-extern NSArray* __nonnull OHMMappableKeys(__nonnull Class c);
+extern NSArray<NSString*>* __nonnull OHMMappableKeys(__nonnull Class c);
 
 /**
  Sets the dictionary for mapping keys.

--- a/Core/ObjectMapping.m
+++ b/Core/ObjectMapping.m
@@ -332,12 +332,12 @@ void OHMRemoveMapping(Class c, NSArray *array)
 
 #pragma mark - Adapter
 
-void OHMSetAdapter(Class c, NSDictionary *adapterDicionary)
+void OHMSetAdapter(Class c, NSDictionary<NSString*, OHMValueAdapterBlock> *adapterDicionary)
 {
     ohm_set_for_key(c, adapterDicionary, &_kOMClassAdapterDictionaryKey);
 }
 
-void OHMSetReverseAdapter(Class c, NSDictionary *adapterDicionary)
+void OHMSetReverseAdapter(Class c, NSDictionary<NSString*, OHMValueAdapterBlock> *adapterDicionary)
 {
     ohm_set_for_key(c, adapterDicionary, &_kOMClassReverseAdapterDictionaryKey);
 }

--- a/Core/ObjectMapping.m
+++ b/Core/ObjectMapping.m
@@ -122,6 +122,11 @@ static NSDictionary * f_ohm_mapping(Class c);
         if (adapterForKey) {
             dictionary[key] = adapterForKey(dictionary[key]);
         }
+
+        // Remove any keys whose values won't be encodable
+        if (![dictionary[key] conformsToProtocol: @protocol(NSCoding)]) {
+            [dictionary removeObjectForKey: key];
+        }
     }
  
     NSMutableDictionary *mapping = [f_ohm_mapping([self class]) mutableCopy];

--- a/Core/ObjectMapping.m
+++ b/Core/ObjectMapping.m
@@ -400,13 +400,18 @@ void OHMRemoveDictionary(Class c, NSArray *keyArray)
 NSArray* OHMMappableKeys(Class c)
 {
     NSMutableArray *mutable = [[NSMutableArray alloc] init];
-    while (strcmp(class_getName(c),"NSObject")) {
+    while (strcmp(class_getName(c), "NSObject")) {
         unsigned int count = 0;
         objc_property_t *properties = class_copyPropertyList(c, &count);
         for (int i = 0 ; i < count ; i++) {
             objc_property_t property = properties[i];
-            NSString *name = [NSString stringWithFormat: @"%s", property_getName(property)];
-            [mutable addObject: name];
+            const char *name = property_getName(property);
+            if (strcmp(name, "hash") &&
+                strcmp(name, "superclass") &&
+                strcmp(name, "description") &&
+                strcmp(name, "debugDescription")) {
+                [mutable addObject: @(name)];
+            }
         }
         free(properties);
         c = class_getSuperclass(c);


### PR DESCRIPTION
In real world use we found that it is useful to omit hash, superclass, description, and debugDescription from the serialized properties.
